### PR TITLE
DIP-0002: Ad Offer Metadata Schema

### DIFF
--- a/dip-0002.md
+++ b/dip-0002.md
@@ -10,62 +10,110 @@ To effectively link ad offer metadata with **d>sponsor** smart contracts, the fo
 
 1. **Metadata Storage**: Metadata should be organized in a JSON format and stored on IPFS (InterPlanetary File System), ensuring decentralization and availability.
 2. **Metadata Linkage**: When creating an ad offer through the **d>sponsor** offer creation smart contract, the IPFS link containing the metadata should be submitted as the `offerMetadata` argument.
-3. **Metadata Accessibility**: A subgraph or any smart contract gateway is tasked with fetching and parsing the JSON metadata from the IPFS link, as denoted by the `offerMetadata` argument provided by the `UpdateOffer` event. Creators metadata should be updated and linked to a `creatorAddress`.
+3. **Metadata Accessibility**: A subgraph or any smart contract gateway is tasked with fetching and parsing the JSON metadata from the IPFS link, as denoted by the `offerMetadata` argument provided by the `UpdateOffer` event. Creators metadata should be updated and linked to an  `address`.
 
 ## Schema Definition
 
 Below is the proposed schema for the ad offer metadata, detailing the keys and their descriptions. This schema is designed to encapsulate essential information about the ad offers, facilitating a comprehensive understanding of each offer's nuances and requirements.
 
-| Key                | Description |
-|--------------------|-------------|
-| `creatorName`      | The name of the creator or entity offering the ad space. |
-| `creatorDescription` | A brief description of the creator or entity. |
-| `creatorImg`       | A URL to an image of the creator or entity's logo. |
-| `creatorCategories`  | Categories that describe the creator or entity's industry or focus areas. |
-| `exposureCategories` | Categories that describe the type of exposure or audience the ad offer targets. |
-| `offerName`        | The name of the ad offer. |
-| `offerDescription` | A detailed description of what the ad offer entails. |
-| `offerImg`         | A URL to an image representing the ad offer. |
-| `terms`            | A link to the terms and conditions of the ad offer, ideally stored on IPFS. |
-| `validFromDate`    | The start date from when the ad offer is valid. |
-| `validToDate`      | The end date until when the ad offer remains valid. |
+| Key                       | Description |
+|---------------------------|-------------|
+| `creator.name`            | The name of the creator or entity offering the ad space.|
+| `creator.description`     | A brief description of the creator or entity.|
+| `creator.image`           | A URL to an image of the creator or entity's logo.|
+| `creator.external_link`   | A link to the creator's external website.|
+| `creator.categories`      | Categories describing the creator or entity's industry or focus areas.|
+| `offer.name`              | The name of the ad offer.|
+| `offer.description`       | A detailed description of what the ad offer entails, including information about the tokenization of ad spaces and the rights provided to the buyers.|
+| `offer.image`             | A URL to an image representing the ad offer.|
+| `offer.terms`             | A link to the terms and conditions of the ad offer.|
+| `offer.external_link`     | An external link related to the offer, where the ad integration is visible for example.|
+| `offer.valid_from`        | The start date from when the ad offer is valid.|
+| `offer.valid_to`          | The end date until when the ad offer remains valid.|
+| `offer.categories`        | Categories describing the type of exposure or audience the ad offer targets.|
+| `offer.token_metadata.name`     | A template name for a tokenized ad space.|
+| `offer.token_metadata.description` | A detailed description of a tokenized ad space.|
+| `offer.token_metadata.image`    | A URL to a image for a tokenized ad space.|
+| `offer.token_metadata.external_url` | An external URL related to a tokenized ad space.|
+| `offer.token_metadata.attributes` | Attributes of a tokenized ad space. |
+
+**Note:** All these fields are optionnal
+
+### Descriptions
+
+Descriptions (`description` keys) may:
+
+* include a `\n` to render a breakline
+* be in Markdown format
+
+### Images and external Links
+
+Links (`terms`, `external_link` & `image` keys) may be from IPFS, Arweave, or HTTPS protocols.
+
+### Dates
+
+* If `valid_from` is not provided, the default value is `1970-01-01T00:00:00Z`
+* If `valid_to` is not provided, the default value is `2100-01-01T00:00:00Z`
+
+### Token metadata
+
+`offer.token_metadata` is structured according [the ERC721 metadata standard](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md). When generating metadata for a specific tokenized ad space, the `{tokenData}` placeholder should be replaced with the `tokenData` value specified on `DSponsorNFT.Mint` event.
 
 ### Example Schema JSON
 
 ```json
-// to upload on IPFS, and set IPFS link as `offerMetadata` argument on create and update offer smart contracts functions
 {
-    "creatorName": "ExampleCreator",
-    "creatorDescription": "ExampleCreator makes it easier to find information online",
-    "creatorImg": "https://example-link-url.com/image.png",
-    "creatorCategories": [
-        "media",
-        "education"
-    ],
-    "exposureCategories": [
-        "DeFi",
-        "NFT",
-        "Crypto"
-    ],
-    "offerName": "ExampleOfferName",
-    "offerDescription": "Ad spaces for ExampleCreator search results",
-    "offerImg": "https://example-link-url.com/offerimage.png",
-    "terms": "ipfs://ExampleTermsLinkPlaceholder",
-    "validFromDate": "2024-01-01T00:00:00Z",
-    "validToDate": "2024-12-31T23:59:59Z"
+    "creator": {
+        "name": "Example - Creator name",
+        "description": "This is a creator description\n.Yes it should support break lines.",
+        "image": "https://whatever.ipfs.nftstorage.link/",
+        "external_link": "https://creator.io",
+        "categories": [
+            "dApp",
+            "social",
+            "media",
+            "education"
+        ]
+    },
+    "offer": {
+        "name": "Example - Offer name",
+        "description": "This is an offer description\n.Yes it should support break lines.",
+        "image": "ipfs:/ipfsHash",
+        "terms": "https://whateverterms.ipfs.nftstorage.link/",
+        "external_link": "https://wheretheintegration.isvisible.com",
+        "valid_from": "2024-04-01T00:00:00Z",
+        "valid_to": "2024-07-31T23:59:59Z",
+        "categories": [
+            "Community",
+            "NFT",
+            "Crypto"
+        ],
+        "token_metadata": {
+            "name": "#{tokenData} - Tokenized Ad Space",
+            "description": "Tokenized advertisement link to '{tokenData}'\n\nBuying this ad space give you the exclusive right to submit an ad.",
+            "image": "https://placehold.co/400x400?text=SiBorg%20Ad%20Space%0A{tokenData}",
+            "external_link": "https://wherethetokenintegration.isvisible.com",
+            "attributes": [
+                {
+                    "trait_type": "Search Query",
+                    "value": "{tokenData}"
+                }
+            ]
+        }
+    }
 }
 ```
 
 ## Categories
 
-Having specific `creatorCategories` and `exposureCategories` keys is crucial for several reasons:
+Having specific `creator.categories` and `offer.categories` keys is crucial for several reasons:
 
-- Organization: Helps in organizing the d>sponsor marketplace more effectively, making it easier for users to navigate and explore.
-- Improved Matching: Facilitates better matching between creators’ offerings and potential sponsors or buyers looking for specific types of exposure or content.
-- Enhanced Analytics: Provides data for analytics on trending categories, helping inform creators and the platform on market demands.
-- Community Building: Aids in building communities around specific interests, fostering engagement within the marketplace.
+* Organization: Helps in organizing the d>sponsor marketplace more effectively, making it easier for users to navigate and explore.
+* Improved Matching: Facilitates better matching between creators’ offerings and potential sponsors or buyers looking for specific types of exposure or content.
+* Enhanced Analytics: Provides data for analytics on trending categories, helping inform creators and the platform on market demands.
+* Community Building: Aids in building communities around specific interests, fostering engagement within the marketplace.
 
-### `creatorCategories`
+### `creator.categories`
 
 Creator categories help classify the wide range of creators based the type of content they produce or the services they offer. Below is a suggested initial list of possible categories:
 
@@ -82,7 +130,7 @@ Creator categories help classify the wide range of creators based the type of co
 | `collectibles`   | Creators of digital collectibles, ranging from virtual trading cards to unique, tokenized memorabilia. |
 | `education`      | Educators and content providers offering courses, workshops, and informational content about Web3, NFTs, and blockchain technology. |
 
-### `exposureCategories`
+### `offer.categories`
 
 Exposure categories are designed to highlight the various audiences and market segments that creators aim to reach, based on their content, utility, or community focus. Below is a suggested initial list of possible categories:
 
@@ -101,4 +149,4 @@ Exposure categories are designed to highlight the various audiences and market s
 
 ## Final Note
 
-This proposalrepresents a first draft aimed at establishing a structured approach for integrating metadata within the **d>sponsor** ad offers. The inclusion of specified `creatorCategories` and `exposureCategories` is designed to enhance the marketplace's functionality and user experience, facilitating precise targeting, easier discovery, and better alignment between creators' offerings and the interests of sponsors or collectors. As a living document, it is open to revisions and improvements.
+This proposalrepresents a first draft aimed at establishing a structured approach for integrating metadata within the **d>sponsor** ad offers. The inclusion of specified categories is designed to enhance the marketplace's functionality and user experience, facilitating precise targeting, easier discovery, and better alignment between creators' offerings and the interests of sponsors or collectors. As a living document, it is open to revisions and improvements.

--- a/dip-0002.md
+++ b/dip-0002.md
@@ -10,11 +10,95 @@ To effectively link ad offer metadata with **d>sponsor** smart contracts, the fo
 
 1. **Metadata Storage**: Metadata should be organized in a JSON format and stored on IPFS (InterPlanetary File System), ensuring decentralization and availability.
 2. **Metadata Linkage**: When creating an ad offer through the **d>sponsor** offer creation smart contract, the IPFS link containing the metadata should be submitted as the `offerMetadata` argument.
-3. **Metadata Accessibility**: A subgraph or any smart contract gateway is tasked with fetching and parsing the JSON metadata from the IPFS link, as denoted by the `offerMetadata` argument provided by the `UpdateOffer` event.
+3. **Metadata Accessibility**: A subgraph or any smart contract gateway is tasked with fetching and parsing the JSON metadata from the IPFS link, as denoted by the `offerMetadata` argument provided by the `UpdateOffer` event. Creators metadata should be updated and linked to a `creatorAddress`.
 
 ## Schema Definition
 
 Below is the proposed schema for the ad offer metadata, detailing the keys and their descriptions. This schema is designed to encapsulate essential information about the ad offers, facilitating a comprehensive understanding of each offer's nuances and requirements.
 
-| Key | Description |
-|-----|-------------|
+| Key                | Description |
+|--------------------|-------------|
+| `creatorName`      | The name of the creator or entity offering the ad space. |
+| `creatorDescription` | A brief description of the creator or entity. |
+| `creatorImg`       | A URL to an image of the creator or entity's logo. |
+| `creatorCategories`  | Categories that describe the creator or entity's industry or focus areas. |
+| `exposureCategories` | Categories that describe the type of exposure or audience the ad offer targets. |
+| `offerName`        | The name of the ad offer. |
+| `offerDescription` | A detailed description of what the ad offer entails. |
+| `offerImg`         | A URL to an image representing the ad offer. |
+| `terms`            | A link to the terms and conditions of the ad offer, ideally stored on IPFS. |
+| `validFromDate`    | The start date from when the ad offer is valid. |
+| `validToDate`      | The end date until when the ad offer remains valid. |
+
+### Example Schema JSON
+
+```json
+// to upload on IPFS, and set IPFS link as `offerMetadata` argument on create and update offer smart contracts functions
+{
+    "creatorName": "ExampleCreator",
+    "creatorDescription": "ExampleCreator makes it easier to find information online",
+    "creatorImg": "https://example-link-url.com/image.png",
+    "creatorCategories": [
+        "media",
+        "education"
+    ],
+    "exposureCategories": [
+        "DeFi",
+        "NFT",
+        "Crypto"
+    ],
+    "offerName": "ExampleOfferName",
+    "offerDescription": "Ad spaces for ExampleCreator search results",
+    "offerImg": "https://example-link-url.com/offerimage.png",
+    "terms": "ipfs://ExampleTermsLinkPlaceholder",
+    "validFromDate": "2024-01-01T00:00:00Z",
+    "validToDate": "2024-12-31T23:59:59Z"
+}
+```
+
+## Categories
+
+Having specific `creatorCategories` and `exposureCategories` keys is crucial for several reasons:
+
+- Organization: Helps in organizing the d>sponsor marketplace more effectively, making it easier for users to navigate and explore.
+- Improved Matching: Facilitates better matching between creators’ offerings and potential sponsors or buyers looking for specific types of exposure or content.
+- Enhanced Analytics: Provides data for analytics on trending categories, helping inform creators and the platform on market demands.
+- Community Building: Aids in building communities around specific interests, fostering engagement within the marketplace.
+
+### `creatorCategories`
+
+Creator categories help classify the wide range of creators based the type of content they produce or the services they offer. Below is a suggested initial list of possible categories:
+
+| Key              | Description |
+|------------------|-------------|
+| `dApp`           | Developers and teams focusing on decentralized applications that run on blockchain technology. |
+| `social`         | Creators leveraging social platforms and networks to engage with audiences in the Web3 space. |
+| `media`          | Content creators producing articles, videos, and podcasts about Web3, blockchain, and NFTs. |
+| `digitalArt`     | Artists creating and tokenizing digital artwork as NFTs, including illustrations and animations. |
+| `blockchainTech` | Innovators working on blockchain technology advancements and infrastructure. |
+| `cryptoAnalysis` | Experts providing analysis and insights on cryptocurrency markets and trends. |
+| `virtualGoods`   | Creators and merchants offering virtual goods and assets, including NFTs, in-game items, and metaverse properties. |
+| `musicNFTs`      | Musicians and sound artists creating unique audio experiences and music tracks as NFTs. |
+| `collectibles`   | Creators of digital collectibles, ranging from virtual trading cards to unique, tokenized memorabilia. |
+| `education`      | Educators and content providers offering courses, workshops, and informational content about Web3, NFTs, and blockchain technology. |
+
+### `exposureCategories`
+
+Exposure categories are designed to highlight the various audiences and market segments that creators aim to reach, based on their content, utility, or community focus. Below is a suggested initial list of possible categories:
+
+| Key              | Description |
+|------------------|-------------|
+| `DeFi`           | Projects and offerings related to decentralized finance, including protocols, platforms, and financial tools. |
+| `NFT`            | Exposure categories focused on non-fungible tokens, covering art, collectibles, utilities, and more. |
+| `Crypto`         | Categories related to cryptocurrency projects, tokens, and blockchain-based financial systems. |
+| `Gaming`         | NFTs and projects in the blockchain gaming sector, including play-to-earn models and virtual economies. |
+| `Metaverse`      | Creations and opportunities within virtual worlds, including real estate, events, and metaverse development. |
+| `ArtTech`        | Technology-driven art projects, including AR/VR experiences, digital installations, and interactive art NFTs. |
+| `Sustainability` | Projects focusing on environmental sustainability, green technology in blockchain, and eco-friendly NFTs. |
+| `Education`      | NFTs and content dedicated to educating users about blockchain, cryptocurrencies, and the NFT market. |
+| `UtilityNFTs`    | NFTs that offer real-world utility, access to services, memberships, or physical product claims. |
+| `Community`      | Projects and NFTs designed to build or enhance community engagement, including DAOs and community tokens. |
+
+## Final Note
+
+This proposalrepresents a first draft aimed at establishing a structured approach for integrating metadata within the **d>sponsor** ad offers. The inclusion of specified `creatorCategories` and `exposureCategories` is designed to enhance the marketplace's functionality and user experience, facilitating precise targeting, easier discovery, and better alignment between creators' offerings and the interests of sponsors or collectors. As a living document, it is open to revisions and improvements.

--- a/dip-0002/schema.json
+++ b/dip-0002/schema.json
@@ -1,0 +1,99 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Ad Offer Metadata",
+    "type": "object",
+    "properties": {
+        "creatorName": {
+            "type": "string",
+            "description": "The name of the creator or entity offering the ad space."
+        },
+        "creatorDescription": {
+            "type": "string",
+            "description": "A brief description of the creator or entity."
+        },
+        "creatorImg": {
+            "type": "string",
+            "format": "uri",
+            "description": "A URL to an image of the creator or entity's logo."
+        },
+        "creatorCategories": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "dApp",
+                    "social",
+                    "media",
+                    "digitalArt",
+                    "blockchainTech",
+                    "cryptoAnalysis",
+                    "virtualGoods",
+                    "musicNFTs",
+                    "collectibles",
+                    "education"
+                ]
+            },
+            "description": "Categories that describe the creator or entity's industry or focus areas."
+        },
+        "exposureCategories": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "DeFi",
+                    "NFT",
+                    "Crypto",
+                    "Gaming",
+                    "Metaverse",
+                    "ArtTech",
+                    "Sustainability",
+                    "Education",
+                    "UtilityNFTs",
+                    "Community"
+                ]
+            },
+            "description": "Categories that describe the type of exposure or audience the ad offer targets."
+        },
+        "offerName": {
+            "type": "string",
+            "description": "The name of the ad offer."
+        },
+        "offerDescription": {
+            "type": "string",
+            "description": "A detailed description of what the ad offer entails."
+        },
+        "offerImg": {
+            "type": "string",
+            "format": "uri",
+            "description": "A URL to an image representing the ad offer."
+        },
+        "terms": {
+            "type": "string",
+            "format": "uri",
+            "description": "A link to the terms and conditions of the ad offer, ideally stored on IPFS."
+        },
+        "validFromDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The start date from when the ad offer is valid."
+        },
+        "validToDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The end date until when the ad offer remains valid."
+        }
+    },
+    "required": [
+        "creatorName",
+        "creatorDescription",
+        "creatorImg",
+        "creatorCategories",
+        "exposureCategories",
+        "offerName",
+        "offerDescription",
+        "offerImg",
+        "terms",
+        "validFromDate",
+        "validToDate"
+    ]
+}

--- a/dip-0002/schema.json
+++ b/dip-0002/schema.json
@@ -1,99 +1,106 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Ad Offer Metadata",
+    "title": "Ad Offer Metadata Schema",
     "type": "object",
     "properties": {
-        "creatorName": {
-            "type": "string",
-            "description": "The name of the creator or entity offering the ad space."
+        "creator": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "external_link": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
         },
-        "creatorDescription": {
-            "type": "string",
-            "description": "A brief description of the creator or entity."
-        },
-        "creatorImg": {
-            "type": "string",
-            "format": "uri",
-            "description": "A URL to an image of the creator or entity's logo."
-        },
-        "creatorCategories": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "enum": [
-                    "dApp",
-                    "social",
-                    "media",
-                    "digitalArt",
-                    "blockchainTech",
-                    "cryptoAnalysis",
-                    "virtualGoods",
-                    "musicNFTs",
-                    "collectibles",
-                    "education"
-                ]
-            },
-            "description": "Categories that describe the creator or entity's industry or focus areas."
-        },
-        "exposureCategories": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "enum": [
-                    "DeFi",
-                    "NFT",
-                    "Crypto",
-                    "Gaming",
-                    "Metaverse",
-                    "ArtTech",
-                    "Sustainability",
-                    "Education",
-                    "UtilityNFTs",
-                    "Community"
-                ]
-            },
-            "description": "Categories that describe the type of exposure or audience the ad offer targets."
-        },
-        "offerName": {
-            "type": "string",
-            "description": "The name of the ad offer."
-        },
-        "offerDescription": {
-            "type": "string",
-            "description": "A detailed description of what the ad offer entails."
-        },
-        "offerImg": {
-            "type": "string",
-            "format": "uri",
-            "description": "A URL to an image representing the ad offer."
-        },
-        "terms": {
-            "type": "string",
-            "format": "uri",
-            "description": "A link to the terms and conditions of the ad offer, ideally stored on IPFS."
-        },
-        "validFromDate": {
-            "type": "string",
-            "format": "date-time",
-            "description": "The start date from when the ad offer is valid."
-        },
-        "validToDate": {
-            "type": "string",
-            "format": "date-time",
-            "description": "The end date until when the ad offer remains valid."
+        "offer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "terms": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "external_link": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "valid_from": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "valid_to": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "token_metadata": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "image": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "external_link": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "attributes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "trait_type": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "trait_type",
+                                    "value"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
         }
-    },
-    "required": [
-        "creatorName",
-        "creatorDescription",
-        "creatorImg",
-        "creatorCategories",
-        "exposureCategories",
-        "offerName",
-        "offerDescription",
-        "offerImg",
-        "terms",
-        "validFromDate",
-        "validToDate"
-    ]
+    }
 }


### PR DESCRIPTION
This pull request introduces a JSON Schema for d>sponsor ad offer metadata to associate on creation.

* `dip-0002.md` defines essential information fields for ad offers, including creator details, categories, offer specifics, and validity dates
* `dip-0002/schema.json` leverages JSON Schema Draft 07 for format specification, ensuring wide compatibility and ease of integration